### PR TITLE
Bugfix.

### DIFF
--- a/hangomat.php
+++ b/hangomat.php
@@ -1562,13 +1562,15 @@ class hangoHelper
 			'Buchstaben',
 			'Wort',
 			'SWort',
-			'characters'
+			'characters',
+			'Tag'
 		);
 		$values =  array(
 			$this->db->q(implode('', $this->moeglicheBuchstaben_array)),
 		 	$this->db->q($Wort),
 			$this->db->q($SWort),
-			$this->db->q(json_encode($characters))
+			$this->db->q(json_encode($characters)),
+			$this->db->q($this->heuteTag)
 		);
 		$query = $this->db->getQuery(true);
 		$query->insert($this->db->qn($this->hangomat))


### PR DESCRIPTION
Without date Tag in newly created entry in before empty #__hangomat a Tagwechsel will run after reload of page.